### PR TITLE
Refactor: Optimize message retrieval query

### DIFF
--- a/src/main/kotlin/com/example/kotlin/chat/repository/MessageRepository.kt
+++ b/src/main/kotlin/com/example/kotlin/chat/repository/MessageRepository.kt
@@ -22,7 +22,6 @@ interface MessageRepository : CoroutineCrudRepository<Message, String> {
         SELECT * FROM (
             SELECT * FROM MESSAGES
             WHERE SENT > (SELECT SENT FROM MESSAGES WHERE ID = :id)
-            ORDER BY "SENT" DESC 
         ) ORDER BY "SENT"
     """)
     fun findLatest(@Param("id") id: String): Flow<Message>


### PR DESCRIPTION
Optimized a SQL query in `MessageRepository.kt` by removing a redundant `ORDER BY "SENT" DESC` clause from its inner subquery.

The inner `ORDER BY` was unnecessary because the outer query already sorts the results by `SENT` in ascending order. Removing this redundant sort simplifies the query and provides a minor performance improvement by avoiding an extra sorting operation.